### PR TITLE
Update instructions on installing Angular CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Make sure you have `node` (version 6.*) installed. Then install dependencies wit
     # Install typescript development support if necessary
     npm install -g tsd
     # Install angular-cli
-    npm install -g angular-cli
+    npm install -g @angular/cli
     # Install dependencies
     npm install
 


### PR DESCRIPTION
The name `angular-cli` is deprecated and doesn't have the latest versions. New name is `@angular/cli`.