### PR TITLE
Add node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ngx-clipboard": "^11.1.9",
     "ngx-markdown": "^6.3.0",
     "ngx-order-pipe": "^2.0.1",
+    "node-sass", "^4.9.4",
     "marked": "^0.5.1",
     "rxjs": "^6.3.3",
     "rxjs-tslint": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ngx-clipboard": "^11.1.9",
     "ngx-markdown": "^6.3.0",
     "ngx-order-pipe": "^2.0.1",
-    "node-sass", "^4.9.4",
+    "node-sass": "^4.9.4",
     "marked": "^0.5.1",
     "rxjs": "^6.3.3",
     "rxjs-tslint": "^0.1.5",


### PR DESCRIPTION
node-sass is required during the build `npm run buildprod` step.