### PR TITLE
Small changes in credentials (esp. relating to Azure)

### DIFF
--- a/src/app/my-profile/components/cloud-credentials-editor/azure-cred-editor/azure-cred-editor.component.html
+++ b/src/app/my-profile/components/cloud-credentials-editor/azure-cred-editor/azure-cred-editor.component.html
@@ -59,7 +59,8 @@
                 placeholder="Which Azure Storage Account would you like to use?"
                 formControlName="storage_account" />
                 <mat-error *ngIf="storageAccountCtrl.hasError('required')">Storage Account is <strong>required</strong></mat-error>
-                <mat-hint>A new storage account will be created if the specified account doesn't exist. You can leave the defaults as is if you're unsure.</mat-hint>
+                <mat-hint>A new Storage Account will be created if the specified account doesn't exist. Leaving the default name is not recommended, given that the name must be
+                    unique across all existing storage account names in Azure. It must be 3 to 24 characters long, and can contain only lowercase letters and numbers.</mat-hint>
             </mat-form-field>
         </div>
         <!-- Azure VM Default User Name -->

--- a/src/app/my-profile/components/cloud-credentials-editor/azure-cred-editor/azure-cred-editor.component.ts
+++ b/src/app/my-profile/components/cloud-credentials-editor/azure-cred-editor/azure-cred-editor.component.ts
@@ -42,7 +42,7 @@ export class AzureCredEditorComponent implements ControlValueAccessor, Validator
     tenantCtrl: FormControl = new FormControl(null, Validators.required);
     resourceGroupCtrl: FormControl = new FormControl('cloudlaunch', Validators.required);
     storageAccountCtrl: FormControl = new FormControl('clstorage', Validators.required);
-    vmDefaultUserCtrl: FormControl = new FormControl('cluser', Validators.required);
+    vmDefaultUserCtrl: FormControl = new FormControl('ubuntu', Validators.required);
 
 
     // Begin: implementation of ControlValueAccessor
@@ -60,7 +60,7 @@ export class AzureCredEditorComponent implements ControlValueAccessor, Validator
             this.azureCredentialsForm.reset(
                 {'resource_group' : 'cloudlaunch',
                 'storage_account': 'clstorage',
-                'vm_default_username': 'cluser'});
+                'vm_default_username': 'ubuntu'});
         }
     }
 

--- a/src/app/my-profile/components/cloud-credentials-editor/cloud-credentials-editor.component.html
+++ b/src/app/my-profile/components/cloud-credentials-editor/cloud-credentials-editor.component.html
@@ -3,7 +3,7 @@
 
         <div class="alert alert-danger" role="alert" *ngIf="errorMessage">
             <span class="glyphicon glyphicon-exclamation-sign"
-                aria-hidden="true"></span> <span class="sr-only">Error:</span> {{ errorMessage }}
+                aria-hidden="true"></span> <span class="sr-only">Error:</span> {{ errorMessage }} <br><br> {{ errorDetails }}
         </div>
 
         <!-- Cloud -->

--- a/src/app/my-profile/components/cloud-credentials-editor/cloud-credentials-editor.component.ts
+++ b/src/app/my-profile/components/cloud-credentials-editor/cloud-credentials-editor.component.ts
@@ -276,7 +276,9 @@ export class CloudCredentialsEditorComponent implements OnInit, ControlValueAcce
         if (result.result === 'SUCCESS') {
             successCallback(creds);
         } else {
-            this.handleVerificationFailure(creds, 'The credentials you have entered are invalid.', failureCallback);
+            const message = 'The credentials you have entered could not be \
+                validated.\nERROR Details: ' + result.details;
+            this.handleVerificationFailure(creds, message, failureCallback);
         }
     }
 

--- a/src/app/my-profile/components/cloud-credentials-editor/cloud-credentials-editor.component.ts
+++ b/src/app/my-profile/components/cloud-credentials-editor/cloud-credentials-editor.component.ts
@@ -47,6 +47,7 @@ declare type VerificationFailureCallback = (c: Credentials, error: string) => vo
 export class CloudCredentialsEditorComponent implements OnInit, ControlValueAccessor, Validator {
     allowCloudChange = true;
     errorMessage: string;
+    errorDetails: string;
     _saveIsOptional = false;
     saveIsPressed = false;
     useCredsIsPressed = false;
@@ -245,27 +246,28 @@ export class CloudCredentialsEditorComponent implements OnInit, ControlValueAcce
     verifyCredentials(creds: any, successCallBack: VerificationSuccessCallback,
             failureCallBack: VerificationFailureCallback) {
         this.errorMessage = null;
+        this.errorDetails = null;
         this.credVerificationInProgress = true;
         switch (this.cloud.cloud_type) {
             case 'aws':
                 this._profileService.verifyCredentialsAWS(creds)
                     .subscribe(result => { this.handleVerificationResult(creds, result, successCallBack, failureCallBack); },
-                               error => { this.handleVerificationFailure(creds, error, failureCallBack); });
+                               error => { this.handleVerificationFailure(creds, error, "", failureCallBack); });
                 break;
             case 'openstack':
                 this._profileService.verifyCredentialsOpenStack(creds)
                     .subscribe(result => { this.handleVerificationResult(creds, result, successCallBack, failureCallBack); },
-                               error => { this.handleVerificationFailure(creds, error, failureCallBack); });
+                               error => { this.handleVerificationFailure(creds, error, "", failureCallBack); });
                 break;
             case 'azure':
                 this._profileService.verifyCredentialsAzure(creds)
                     .subscribe(result => { this.handleVerificationResult(creds, result, successCallBack, failureCallBack); },
-                               error => { this.handleVerificationFailure(creds, error, failureCallBack); });
+                               error => { this.handleVerificationFailure(creds, error, "", failureCallBack); });
                 break;
             case 'gce':
                 this._profileService.verifyCredentialsGCE(creds)
                     .subscribe(result => { this.handleVerificationResult(creds, result, successCallBack, failureCallBack); },
-                               error => { this.handleVerificationFailure(creds, error, failureCallBack); });
+                               error => { this.handleVerificationFailure(creds, error, "", failureCallBack); });
                 break;
         }
     }
@@ -276,15 +278,16 @@ export class CloudCredentialsEditorComponent implements OnInit, ControlValueAcce
         if (result.result === 'SUCCESS') {
             successCallback(creds);
         } else {
-            const message = 'The credentials you have entered could not be \
-                validated.\nERROR Details: ' + result.details;
-            this.handleVerificationFailure(creds, message, failureCallback);
+            const message = 'The credentials you have entered could not be validated.';
+            const dets = 'ERROR Details: ' + result.details;
+            this.handleVerificationFailure(creds, message, dets, failureCallback);
         }
     }
 
-    handleVerificationFailure(creds: Credentials, error: any, failureCallback: VerificationFailureCallback) {
+    handleVerificationFailure(creds: Credentials, error: any, details: any, failureCallback: VerificationFailureCallback) {
         this.credVerificationInProgress = false;
         this.errorMessage = error;
+        this.errorDetails = details;
         failureCallback(creds, error);
     }
 


### PR DESCRIPTION
Given that some "invalid credentials" errors could appear when the authentication parts of the provided credentials are correct but other fields are not complying with restrictions (example: using invalid characters in the Resource Group name for Azure, or using an already existing Storage Account given that they have to be unique across ALL Azure accounts), displaying the actual error message when credentials cannot be verified can be very helpful for users trying to figure out what parts they need to change.
The other changes are minor changes to the Azure credentials to better guide users